### PR TITLE
Load the UX banner from GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <head>
-  <script type="text/javascript" src="https://raw.githubusercontent.com/FirefoxUX/SharedBanner/master/dist/fxux-banner.min.js"></script>
+  <script type="text/javascript" src="https://firefoxux.github.io/SharedBanner/fxux-banner.min.js"></script>
 </head>
 <body>
  <h1>Hello there!</h1>


### PR DESCRIPTION
Note that this was broken before because raw.githubusercontent.com serves things as text/plain, so the browser would refuse to run the JS.