### PR TITLE
use relative link to SharedBanner

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="style.css">
-    <script type="text/javascript" src="http://design.firefox.com/SharedBanner/fxux-banner.min.js"></script>
+    <script type="text/javascript" src="/SharedBanner/fxux-banner.min.js"></script>
   </head>
   <body>
     <div id="contents">


### PR DESCRIPTION
Otherwise, mixed-content warnings will pop up under https://